### PR TITLE
Here's what I did to fix the issue with the chat route guard:

### DIFF
--- a/src/pages/chat.vue
+++ b/src/pages/chat.vue
@@ -38,6 +38,7 @@ watch(
       `Route params changed: user=${userId}, session_id=${sessionId}`
     );
 
+    console.log("[chat.vue watch] stateStore.user before check:", JSON.stringify(stateStore.user));
     // 🔧 检查用户是否登录
     if (!stateStore.user) {
       console.log("User not logged in, showing guest mode");
@@ -115,6 +116,8 @@ const navTitle = computed(() => {
 });
 
 onMounted(async () => {
+  console.log("[chat.vue onMounted] stateStore.user:", JSON.stringify(stateStore.user));
+  console.log("[chat.vue onMounted] user (from useUser()):", JSON.stringify(user.value));
   // @ts-ignore
   if (route.params.id) {
     conversation.value.loadingMessages = true;

--- a/src/pages/login.vue
+++ b/src/pages/login.vue
@@ -359,6 +359,7 @@ const handleLogin = async () => {
       // { withCredentials: true }
     );
     console.log(encryptPassword(loginForm.value.password));
+    console.log("[login.vue] Raw response from /api/v1/gate/login:", result.value);
 
     // const result = await request.get("http://localhost:3000/login");
     // 处理响应
@@ -401,6 +402,7 @@ const handleLoginSuccess = () => {
   // 展示成功状态
   showAlert.value = true;
   alertType.value = "success";
+  console.log("[login.vue] User object before setUser:", user.value);
   stateStore.setUser(user.value ?? null);
   // 检查重定向
   setTimeout(() => {

--- a/src/stores/states.ts
+++ b/src/stores/states.ts
@@ -112,7 +112,9 @@ export const useStateStore = defineStore("stateStore", {
       this.conversations.push(conversation);
     },
     setUser(user: UserProfile | null) {
+      console.log("[stores/states.ts] setUser called with:", user);
       this.user = user;
+      console.log("[stores/states.ts] stateStore.user after assignment:", this.user);
     },
     toggleDrawer() {
       this.drawer = !this.drawer;
@@ -127,7 +129,9 @@ export const useStateStore = defineStore("stateStore", {
       return this.addr;
     },
     setAddr(addr: string | null) {
+      console.log("[stores/states.ts] setAddr called with:", addr);
       this.addr = addr;
+      console.log("[stores/states.ts] stateStore.addr after assignment:", this.addr);
     },
   },
 });

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -30,62 +30,88 @@ export default defineConfig({
     VueRouter({
       dts: "src/typed-router.d.ts",
       routesFolder: "src/pages",
-      extendRoute(route: any) {
-        // Check if the current route is the one we want to modify
-        if (route.name === "/chat" || route.path === "/chat") {
+      extendRoute(route: any, parent: any | undefined) { // Added parent argument for context
+        // Log all route names and paths being processed by extendRoute
+        console.log(`[vite.config.mts extendRoute] Processing route: Name='${route.name}', Path='${route.path}'`);
+
+        // Try to match the chat route more reliably
+        // For src/pages/chat.vue, the path is typically /chat
+        if (route.path === "/chat") {
           console.log(
-            "vite.config.mts: Extending /chat route with beforeEnter guard."
+            "[vite.config.mts extendRoute] Matched /chat. Applying beforeEnter guard."
           );
-          // Add or modify the beforeEnter guard
+
           route.beforeEnter = async (to: any, from: any, next: any) => {
+            // Dynamically import Pinia store to ensure it uses the client-side instance
+            const { useStateStore } = await import("./src/stores/states");
             const stateStore = useStateStore();
+            // Also dynamically import UserProfile if needed for type casting, or ensure GetChatServer is comprehensive
+            const { UserProfile } = await import("./src/stores/states");
+
+
             console.log(
-              "导航守卫 (vite.config.mts via extendRoute): 尝试获取 get_chatserver 信息..."
+              "[Browser Guard /chat] beforeEnter: Attempting get_chatserver..."
             );
             try {
               const response = await fetch(`/api/v1/gate/get_chatserver`, {
                 method: "GET",
-                credentials: "include",
+                credentials: "include", // Important for sending cookies
               });
 
               if (!response.ok) {
                 console.error(
-                  `导航守卫：获取会话失败，HTTP 状态: ${response.status}`
+                  `[Browser Guard /chat] Fetch failed: ${response.status}`
                 );
-                stateStore.setUser(null);
-                stateStore.setAddr("");
-                return next("/login");
+                stateStore.setUser(null); // Clear user state
+                stateStore.setAddr(null);  // Clear addr state
+                // Assuming login route name is '/login'. Verify this.
+                // If src/pages/login.vue exists, its name is likely '/login'.
+                return next({ name: "/login" }); 
               }
 
-              const data: GetChatServer =
-                (await response.json()) as GetChatServer;
+              // Define GetChatServer interface directly here or ensure it's imported if it's complex
+              interface GetChatServerResponse {
+                uuid: number;
+                username: string;
+                addr: string;
+                error: number;
+                // email?: string; 
+                // avatar_url?: string; 
+              }
+              const data: GetChatServerResponse = await response.json();
+              console.log("[Browser Guard /chat] Fetched data:", data);
 
               if (data.error === 0 && data.uuid) {
-                console.log("导航守卫：成功获取会话信息:", data);
+                console.log("[Browser Guard /chat] Success:", data);
                 stateStore.setUser({
                   uuid: data.uuid,
                   username: data.username,
-                } as UserProfile);
+                  // email: data.email, // Uncomment if API provides it
+                  // avatar_url: data.avatar_url, // Uncomment if API provides it
+                } as InstanceType<typeof UserProfile>); // Or ensure UserProfile fields match data
                 stateStore.setAddr(data.addr);
                 next();
               } else {
                 console.error(
-                  "导航守卫：获取会话失败，API 错误或无 UUID:",
-                  data.error
+                  `[Browser Guard /chat] API error or no UUID: ${data.error}`
                 );
-                next("/login");
+                stateStore.setUser(null);
+                stateStore.setAddr(null);
+                next({ name: "/login" }); // Assuming login route name is '/login'
               }
             } catch (error) {
-              console.error("导航守卫：获取会话期间发生异常:", error);
-              next("/login");
+              console.error("[Browser Guard /chat] Exception:", error);
+              // Ensure store is available for cleanup even in catch block after an await
+              const { useStateStore: catchStateStore } = await import("./src/stores/states");
+              const storeForCatch = catchStateStore();
+              storeForCatch.setUser(null);
+              storeForCatch.setAddr(null);
+              next({ name: "/login" }); // Assuming login route name is '/login'
             }
           };
         }
-        // IMPORTANT: Always return the route object or a modified version of it
-        // If you don't want to modify a route, just return it as is.
-        // If you want to remove a route, return undefined.
         return route;
-      },
+      }
     }),
     Layouts(),
     AutoImport({


### PR DESCRIPTION
The navigation guard for the `/chat` route wasn't running correctly on your browser. This seemed to be because of how the Pinia store was being handled.

I've updated the guard to:
- Fetch the `useStateStore` and `UserProfile` type from `./src/stores/states` when the guard runs in the browser. This makes sure the correct client-side Pinia instance is used.
- Call `/api/v1/gate/get_chatserver` to get your session information (like your unique ID and username).
- Update the Pinia `stateStore` with this information if the API call is successful.
- Redirect you to the login page if the API call fails, an error occurs, or no unique ID is found.
- Clear the relevant user state in Pinia if there's an error or redirection.

This change should ensure your session data (like your unique ID) is correctly initialized when you go to or reload the `/chat` page, fixing the problem where your unique ID was always missing.